### PR TITLE
Replace bools with enum

### DIFF
--- a/minesweeper/Controllers/GameController.cs
+++ b/minesweeper/Controllers/GameController.cs
@@ -102,19 +102,23 @@ namespace minesweeper.Controllers
 			return _board!.LossStreakCount;
 		}
 
-		public bool GetIsRoundLost()
+		/// <summary>
+		/// Can either
+		/// </summary>
+		/// <returns>The current state of the board as a string</returns>
+		public string GetCurrentState()
 		{
-			return _board!.IsRoundLost();
+			return _board!.CurrentState.ToString();
 		}
 
-		public bool GetIsRoundWon()
-		{
-			return _board!.IsRoundWon();
-		}
+		//public bool GetIsRoundWon()
+		//{
+		//	return _board!.IsRoundWon();
+		//}
 
-		public bool IsRoundActive()
-		{
-			return _board!.IsRoundActive;
-		}
+		//public bool IsRoundActive()
+		//{
+		//	return _board!.CurrentState;
+		//}
 	}
 }

--- a/minesweeper/Controllers/GameController.cs
+++ b/minesweeper/Controllers/GameController.cs
@@ -102,23 +102,10 @@ namespace minesweeper.Controllers
 			return _board!.LossStreakCount;
 		}
 
-		/// <summary>
-		/// Can either
-		/// </summary>
 		/// <returns>The current state of the board as a string</returns>
 		public string GetCurrentState()
 		{
 			return _board!.CurrentState.ToString();
 		}
-
-		//public bool GetIsRoundWon()
-		//{
-		//	return _board!.IsRoundWon();
-		//}
-
-		//public bool IsRoundActive()
-		//{
-		//	return _board!.CurrentState;
-		//}
 	}
 }

--- a/minesweeper/Models/Board.cs
+++ b/minesweeper/Models/Board.cs
@@ -13,10 +13,11 @@ public class Board
 	int _setFlagCount;
 
 	Cell[,] _cells = new Cell[0, 0];
-	RoundSummary? _summary;
+	RoundSummary _summary = new RoundSummary();
 
 	static int _cellsCount;
-	static RoundState _currentState;			
+	static RoundState _currentState;
+
 	static int _lossStreakCount;
 	static int _originalLifeCount;
 	static Random _random = new Random();
@@ -154,7 +155,10 @@ public class Board
 	/// <param name="myAffectedCells">If a cell gets revealed then itll be added to this list to be shown in the View later.</param>
 	void CellClicked(Cell myCell, ref List<Cell> myAffectedCells)
 	{
-		if (myCell.IsFlagged) { return; }
+		if (_currentState == RoundState.Lost || myCell.IsFlagged)
+		{
+			return;
+		}
 		else if (myCell.IsBomb)
 		{
 			_lifeCount--;
@@ -306,25 +310,20 @@ public class Board
 			cell.IsRevealed = cell.IsRevealed ? cell.IsRevealed : cell.IsBomb;
 		}
 	}
-	
-	/// <returns>True, if the round has been lost, otherwise false, meaning that its won or still running.</returns>
-	//public bool IsRoundLost()
-	//{
-	//	if (LifeCount <= 0)
-	//	{
-	//		_currentState = false;
-	//		return true;
-	//	}
 
-	//	return false;
-	//}
+	/// <summary>
+	/// Iterates though the entire board to verify that every non bomb has been revealed.
+	/// Will also set the current state to be won or still active.
+	/// </summary>
+	/// <returns>True, if the round has been won, otherwise false, meaning that its in a different state.</returns>
+	bool IsRoundWon()
+	{
+		if (_currentState == RoundState.Lost || _currentState == RoundState.NotStarted) { return false; }
 
-	/// <returns>Sets the current state to be won or still active. True, if the round has been won, otherwise false, meaning that its lost or still running.</returns>
-	public bool IsRoundWon()
-	{	//assume player won...
+		//assume player won...
 		bool isWon = true;
 		foreach (Cell cell in _cells)
-		{	//until theres a cell that isnt a bomb and isnt revealed (all non bombs must be revealed to win)
+		{   //until theres a cell that isnt a bomb and isnt revealed (all non bombs must be revealed to win)
 			if (!cell.IsBomb && !cell.IsRevealed)
 			{
 				isWon = false;

--- a/minesweeper/Models/Board.cs
+++ b/minesweeper/Models/Board.cs
@@ -168,7 +168,7 @@ public class Board
 			myCell.IsFlagged = true;
 			myCell.IsExploded = true;
 
-			if (LifeCount <= 0)
+			if (_lifeCount <= 0)
 			{
 				_currentState = RoundState.Lost;
 				_lossStreakCount++;

--- a/minesweeper/Models/Board.cs
+++ b/minesweeper/Models/Board.cs
@@ -16,8 +16,7 @@ public class Board
 	RoundSummary? _summary;
 
 	static int _cellsCount;
-	static bool _isRoundActive;			//todo: replace this with enum containing these active states: running, not started, won, lost, paused. Will replace methods IsRoundLost and -Won
-
+	static RoundState _currentState;			
 	static int _lossStreakCount;
 	static int _originalLifeCount;
 	static Random _random = new Random();
@@ -71,7 +70,7 @@ public class Board
 	{
 		_setFlagCount = 0;
 		_revealedCellsCount = 0;
-		_isRoundActive = false;
+		_currentState = RoundState.NotStarted;
 		_lifeCount = _originalLifeCount;
 	}
 
@@ -143,7 +142,7 @@ public class Board
 
 	public List<Cell> CellClicked(int myColumn, int myRow)
 	{
-		_isRoundActive = true;
+		_currentState = RoundState.Active;
 		List<Cell> affectedCells = new List<Cell>();
 		CellClicked(_cells[myColumn, myRow], ref affectedCells);
 		return affectedCells;
@@ -165,8 +164,9 @@ public class Board
 			myCell.IsFlagged = true;
 			myCell.IsExploded = true;
 
-			if (IsRoundLost())
+			if (LifeCount <= 0)
 			{
+				_currentState = RoundState.Lost;
 				_lossStreakCount++;
 				RevealBombs();
 				return;
@@ -308,20 +308,20 @@ public class Board
 	}
 	
 	/// <returns>True, if the round has been lost, otherwise false, meaning that its won or still running.</returns>
-	public bool IsRoundLost()
-	{
-		if (LifeCount <= 0)
-		{
-			_isRoundActive = false;
-			return true;
-		}
+	//public bool IsRoundLost()
+	//{
+	//	if (LifeCount <= 0)
+	//	{
+	//		_currentState = false;
+	//		return true;
+	//	}
 
-		return false;
-	}
+	//	return false;
+	//}
 
-	/// <returns>True, if the round has been won, otherwise false, meaning that its lost or still running.</returns>
+	/// <returns>Sets the current state to be won or still active. True, if the round has been won, otherwise false, meaning that its lost or still running.</returns>
 	public bool IsRoundWon()
-	{	//assume player won
+	{	//assume player won...
 		bool isWon = true;
 		foreach (Cell cell in _cells)
 		{	//until theres a cell that isnt a bomb and isnt revealed (all non bombs must be revealed to win)
@@ -332,7 +332,7 @@ public class Board
 			}
 		}
 
-		_isRoundActive = !isWon;
+		_currentState = isWon ? RoundState.Won : RoundState.Active;
 		return isWon;
 	}
 
@@ -346,7 +346,11 @@ public class Board
 	/// Shows us how many non bombs there are
 	/// </summary>
 	public long RevealedCellsCount { get => _revealedCellsCount; }
-	public bool IsRoundActive { get => _isRoundActive; }
+
+	/// <summary>
+	/// Current state can either be NotStarted, Active, Lost or Won.
+	/// </summary>
+	public RoundState CurrentState { get => _currentState; }
 	public int BombsCount
 {
 		get => _bombsCount;
@@ -363,4 +367,12 @@ public class Board
 	
 	[JsonIgnore]
 	public RoundSummary Summary { get => _summary!; }
+
+	public enum RoundState
+	{
+		NotStarted,
+		Active,
+		Lost,
+		Won
+	}
 }

--- a/minesweeper/wwwroot/js/cell.js
+++ b/minesweeper/wwwroot/js/cell.js
@@ -48,7 +48,7 @@ function refreshCellEvents() {
                         });
                     }
 
-                    //check if round is lost and call OnRoundFinished
+                    //get the current state and call OnRoundFinished if its lost or won
                     $.get("/Game/GetCurrentState", function (currentState, status) {
                         if (status !== "success") {
                             console.warn("GetCurrentState from server resulted in an error:", currentState);

--- a/minesweeper/wwwroot/js/cell.js
+++ b/minesweeper/wwwroot/js/cell.js
@@ -1,4 +1,9 @@
-﻿/**
+﻿const STATE_NOT_STARTED = "NotStarted";
+const STATE_ACTIVE = "Active";
+const STATE_LOST = "Lost";
+const STATE_WON = "Won";
+
+/**
  * Adds events to all .partialCell divs instead of the cellView/button itself, because partialCell reloads its content (the cellView)
  * so those events dont have to be reattached again. Except if the whole board gets reloaded (restart)
  */
@@ -44,32 +49,18 @@ function refreshCellEvents() {
                     }
 
                     //check if round is lost and call OnRoundFinished
-                    $.get("/Game/GetIsRoundLost", function (isRoundLost, status) {
+                    $.get("/Game/GetCurrentState", function (currentState, status) {
                         if (status !== "success") {
-                            console.warn("GetIsRoundLost from server resulted in an error:", isRoundLost);
+                            console.warn("GetCurrentState from server resulted in an error:", currentState);
                             return;
                         }
 
-                        if (isRoundLost) {
-                            _boardIsRoundFinished = true;
-                            OnRoundFinished(!isRoundLost);
-                            return;
+                        if (currentState == STATE_LOST) {
+                            OnRoundFinished(false);
                         }
-
-                        //check if its won instead and call OnRoundFinished too, otherwise round is still active
-                        $.get("/Game/GetIsRoundWon", function (isRoundWon, status) {
-                            if (status !== "success") {
-                                console.warn("GetIsRoundWon from server resulted in an error:", response);
-                                return;
-                            }
-
-                            if (isRoundWon) {
-                                _boardIsRoundFinished = true;
-                                OnRoundFinished(isRoundWon);
-                                return;
-                            }
-                            _boardIsRoundFinished = false;
-                        });
+                        else if (currentState == STATE_WON) {
+                            OnRoundFinished(true);
+                        }
                     });
 
                     //get the current boardModel to update all stat elements

--- a/minesweeper/wwwroot/js/cell.js
+++ b/minesweeper/wwwroot/js/cell.js
@@ -55,11 +55,8 @@ function refreshCellEvents() {
                             return;
                         }
 
-                        if (currentState == STATE_LOST) {
-                            OnRoundFinished(false);
-                        }
-                        else if (currentState == STATE_WON) {
-                            OnRoundFinished(true);
+                        if (currentState != STATE_ACTIVE && currentState != STATE_NOT_STARTED) {
+                            OnRoundFinished(currentState == STATE_WON);
                         }
                     });
 

--- a/minesweeper/wwwroot/js/game.js
+++ b/minesweeper/wwwroot/js/game.js
@@ -1,9 +1,7 @@
-﻿let _boardModel;
-let _boardIsRoundFinished = false;
-
-let _remainingFlagsStat;
+﻿let _lifesStat;
+let _boardModel;
 let _boardProgressStat;
-let _lifesStat;
+let _remainingFlagsStat;
 
 
 $(document).ready(function () {
@@ -34,14 +32,14 @@ $(document).ready(function () {
 * Will not change life count stat if its undefined.
 */
 function resetRound(sender, customColumn, customRow, customLifesCount) {
-    $.get("/Game/IsRoundActive", function (hasRoundStarted, status) {
-        console.log(`IsRoundActive from server was ${status}`);
+    $.get("/Game/GetCurrentState", function (currentState, status) {
+        console.log(`GetCurrentState from server was ${status}`);
         if (status !== "success") {
-            console.warn(hasRoundStarted);
+            console.warn(currentState);
             return;
         }
 
-        if ((hasRoundStarted && !_boardIsRoundFinished) && !confirm("Applying new settings will also reset the current round." +
+        if ((currentState == STATE_ACTIVE) && !confirm("Applying new settings will also reset the current round." +
             "\nAre you sure you want to continue?")) {
             return;
         }


### PR DESCRIPTION
close #28, an enum has been implemented that reflect the different states the board can be in, effectively replacing the bools and methods determining if the board has been lost or is still active